### PR TITLE
Initial v0.1.0 implementation: core library, tests, pyproject and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Pytest
+        run: pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
-          python-version: "3.11"
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+        run: uv sync --group dev
 
       - name: Ruff lint
-        run: ruff check .
+        run: uv run ruff check .
 
       - name: Pytest
-        run: pytest -q
+        run: uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ formatted_results = format_tool_results(results)
 
 ## CI
 
-GitHub Actions now runs `ruff check .` and `pytest -q` on pushes and pull requests targeting `main`.
+GitHub Actions now uses `uv` to run `ruff check .` and `pytest -q` on pushes and pull requests targeting `main`.
 
 ---
 
@@ -150,8 +150,8 @@ This repository now includes a minimal `v0.1.0` implementation in `src/baretools
 
 Run locally:
 ```bash
-pip install -e .[dev]
-pytest
+uv sync --group dev
+uv run pytest -q
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ formatted_results = format_tool_results(results)
 
 ---
 
+
+## CI
+
+GitHub Actions now runs `ruff check .` and `pytest -q` on pushes and pull requests targeting `main`.
+
+---
+
+## Current Implementation Status
+
+This repository now includes a minimal `v0.1.0` implementation in `src/baretools` with:
+- `@tool` decorator metadata
+- `ToolRegistry.register()` schema generation
+- `ToolRegistry.execute()` with optional parallel execution
+- `parse_tool_calls()` and `format_tool_results()` helpers
+
+Run locally:
+```bash
+pip install -e .[dev]
+pytest
+```
+
+---
+
 ## Installation
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 authors = [{ name = "Baretools AI Contributors" }]
 dependencies = []
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["pytest>=8.0.0", "ruff>=0.5.0"]
 
 [tool.setuptools]
@@ -24,10 +24,12 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 
-
 [tool.ruff]
 line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]
+
+[tool.uv]
+required-version = ">=0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "baretools-ai"
+version = "0.1.0"
+description = "Minimal tooling primitives for LLM tool calling"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Baretools AI Contributors" }]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0", "ruff>=0.5.0"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]

--- a/src/baretools/__init__.py
+++ b/src/baretools/__init__.py
@@ -1,0 +1,8 @@
+from .core import ToolRegistry, format_tool_results, parse_tool_calls, tool
+
+__all__ = [
+    "tool",
+    "ToolRegistry",
+    "parse_tool_calls",
+    "format_tool_results",
+]

--- a/src/baretools/core.py
+++ b/src/baretools/core.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from inspect import Signature, _empty, signature
+from time import perf_counter
+from typing import Any, Callable
+
+JSON_SCHEMA_TYPE_MAP: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    dict: "object",
+}
+
+
+@dataclass(frozen=True)
+class RegisteredTool:
+    name: str
+    description: str
+    function: Callable[..., Any]
+    schema: dict[str, Any]
+
+
+def tool(
+    func: Callable[..., Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+):
+    """Mark a function as a baretools tool with optional metadata overrides."""
+
+    def _decorate(inner: Callable[..., Any]) -> Callable[..., Any]:
+        inner.__baretools_tool__ = True
+        inner.__baretools_name__ = name or inner.__name__
+        inner.__baretools_description__ = description or (inner.__doc__ or "").strip()
+        return inner
+
+    if func is None:
+        return _decorate
+    return _decorate(func)
+
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: dict[str, RegisteredTool] = {}
+
+    def register(self, fn: Callable[..., Any]) -> None:
+        if not callable(fn):
+            raise TypeError("Tool must be callable")
+
+        tool_name = getattr(fn, "__baretools_name__", fn.__name__)
+        description = getattr(fn, "__baretools_description__", (fn.__doc__ or "").strip())
+
+        if tool_name in self._tools:
+            raise ValueError(f"Tool '{tool_name}' already registered")
+
+        sig = signature(fn)
+        schema = _function_to_openai_schema(tool_name, description, sig)
+        self._tools[tool_name] = RegisteredTool(
+            name=tool_name,
+            description=description,
+            function=fn,
+            schema=schema,
+        )
+
+    def get_schemas(self) -> list[dict[str, Any]]:
+        return [tool.schema for tool in self._tools.values()]
+
+    def execute(
+        self,
+        tool_calls: list[dict[str, Any]],
+        parallel: bool = False,
+    ) -> list[dict[str, Any]]:
+        if parallel and len(tool_calls) > 1:
+            with ThreadPoolExecutor() as pool:
+                return list(pool.map(self._execute_one, tool_calls))
+        return [self._execute_one(call) for call in tool_calls]
+
+    def _execute_one(self, tool_call: dict[str, Any]) -> dict[str, Any]:
+        call_id = tool_call.get("id") or tool_call.get("tool_call_id")
+        name = tool_call.get("name")
+        arguments = tool_call.get("arguments", {})
+
+        if isinstance(arguments, str):
+            arguments = json.loads(arguments or "{}")
+
+        started = perf_counter()
+        try:
+            if name not in self._tools:
+                raise KeyError(f"Unknown tool '{name}'")
+
+            output = self._tools[name].function(**arguments)
+            return {
+                "tool_call_id": call_id,
+                "tool_name": name,
+                "output": output,
+                "error": None,
+                "execution_time_ms": _elapsed_ms(started),
+            }
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "tool_call_id": call_id,
+                "tool_name": name,
+                "output": None,
+                "error": str(exc),
+                "execution_time_ms": _elapsed_ms(started),
+            }
+
+
+def parse_tool_calls(message: Any) -> list[dict[str, Any]]:
+    """Parse OpenAI-style message.tool_calls into a normalized internal shape."""
+    raw_calls = getattr(message, "tool_calls", None) or []
+    normalized = []
+    for call in raw_calls:
+        normalized.append(
+            {
+                "id": getattr(call, "id", None),
+                "name": getattr(call.function, "name", None),
+                "arguments": getattr(call.function, "arguments", "{}"),
+            }
+        )
+    return normalized
+
+
+def format_tool_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Format internal tool results for an OpenAI tool-role message append."""
+    formatted = []
+    for result in results:
+        content = result["output"] if result["error"] is None else f"ERROR: {result['error']}"
+        formatted.append(
+            {
+                "role": "tool",
+                "tool_call_id": result["tool_call_id"],
+                "content": str(content),
+            }
+        )
+    return formatted
+
+
+def _function_to_openai_schema(name: str, description: str, sig: Signature) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for param_name, param in sig.parameters.items():
+        if param.kind not in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY):
+            raise TypeError(f"Unsupported parameter kind for '{param_name}': {param.kind}")
+
+        json_type = _annotation_to_json_type(param.annotation)
+        properties[param_name] = {"type": json_type}
+
+        if param.default is _empty:
+            required.append(param_name)
+
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _annotation_to_json_type(annotation: Any) -> str:
+    if annotation is _empty:
+        return "string"
+
+    origin = getattr(annotation, "__origin__", None)
+    if origin is list:
+        return "array"
+    if origin is dict:
+        return "object"
+
+    return JSON_SCHEMA_TYPE_MAP.get(annotation, "string")
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((perf_counter() - start) * 1000)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,46 @@
+from baretools import ToolRegistry, format_tool_results, tool
+
+
+def test_schema_generation_and_execution() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        """Add two numbers"""
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    schemas = registry.get_schemas()
+    assert len(schemas) == 1
+    assert schemas[0]["function"]["name"] == "add"
+
+    results = registry.execute([
+        {"id": "call1", "name": "add", "arguments": {"a": 3, "b": 2}},
+    ])
+
+    assert results[0]["error"] is None
+    assert results[0]["output"] == 5
+
+
+def test_error_is_captured() -> None:
+    @tool
+    def crash() -> None:
+        raise RuntimeError("boom")
+
+    registry = ToolRegistry()
+    registry.register(crash)
+
+    result = registry.execute([{"id": "call2", "name": "crash", "arguments": {}}])[0]
+    assert "boom" in result["error"]
+
+
+def test_format_tool_results() -> None:
+    formatted = format_tool_results(
+        [
+            {"tool_call_id": "c1", "output": "ok", "error": None},
+            {"tool_call_id": "c2", "output": None, "error": "bad"},
+        ]
+    )
+
+    assert formatted[0]["role"] == "tool"
+    assert formatted[1]["content"] == "ERROR: bad"


### PR DESCRIPTION
### Motivation
- Provide a minimal v0.1.0 implementation of tooling primitives for LLM tool calling, including tool registration and execution.
- Add project metadata and developer tooling to enable local development and reproducible CI runs.

### Description
- Add core implementation in `src/baretools/core.py` with a `@tool` decorator, `ToolRegistry` (registration, schema generation, execution with optional parallelism), and helpers `parse_tool_calls` and `format_tool_results`.
- Export public API via `src/baretools/__init__.py` and add unit tests in `tests/test_core.py` covering schema generation, execution, error capture, and result formatting.
- Add packaging configuration in `pyproject.toml` including `dev` extras for `pytest` and `ruff`, and project metadata for `baretools-ai` v0.1.0.
- Add CI workflow `.github/workflows/ci.yml` that runs `ruff check .` and `pytest -q` on pushes and pull requests to `main`, and update `README.md` with CI and implementation status notes.

### Testing
- Run `pytest -q` against `tests/test_core.py` which exercises schema generation, normal execution, error handling, and result formatting, and the test suite passed.
- Run `ruff check .` as part of CI to validate lint rules, and lint checks were included in the CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e883214a98832a9cc11189c6303c42)