### PR TITLE
feat: add multi-provider schema support and provider-aware `get_schemas()`; update schema generation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- version list -->
 
+## v0.2.0 (Unreleased)
+
+- Add multi-provider tool schema support via `ToolRegistry.get_schemas(provider=...)`.
+  Supported providers: `openai` (default), `anthropic`, `gemini`, `json_schema`.
+- Gemini output uses the `functionDeclarations` shape and conforms to the supported
+  OpenAPI subset (no `additionalProperties`; `parameters` and empty `required` are
+  omitted when not needed).
+- `get_schemas()` returns defensive copies so callers can mutate results without
+  affecting the registry.
+- Add opt-in `strict=True` for the `openai` provider, which marks every property
+  as required, unions optional parameters with `null`, and emits `"strict": true`
+  per OpenAI's structured-outputs requirements.
+- **Breaking:** `RegisteredTool.schema` renamed to `RegisteredTool.parameters` and
+  now stores a canonical JSON Schema rather than the OpenAI-wrapped shape.
+  Provider-specific shapes are produced lazily by `get_schemas()`.
+
 ## v0.1.0 (2026-04-22)
 
 - Initial Release

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ schemas = tools.get_schemas("openai")  # or anthropic/gemini/json_schema
 **Output formats:**
 - OpenAI function calling format
 - Anthropic tool use format
+- Gemini function declaration format
 - Generic JSON schema
 
 #### 3. Tool Execution

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ tools = ToolRegistry()
 tools.register(search_web)
 
 # Get LLM-compatible schema
-schemas = tools.get_schemas()  # Returns OpenAI/Anthropic format
+schemas = tools.get_schemas("openai")  # or anthropic/gemini/json_schema
 ```
 
 **Output formats:**
@@ -145,9 +145,9 @@ formatted_results = format_tool_results(results)
 - [x] Error handling
 
 ### 🎯 Phase 2: Multi-Provider (v0.2.0)
-- [ ] Anthropic format support
-- [ ] Google/Gemini format support
-- [ ] Provider-agnostic schema conversion
+- [x] Anthropic format support
+- [x] Google/Gemini format support
+- [x] Provider-agnostic schema conversion
 
 ### 🔮 Phase 3: Developer Experience (v0.3.0)
 - [x] Async tool execution

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ tools = ToolRegistry()
 tools.register(search_web)
 
 # Get LLM-compatible schema
-schemas = tools.get_schemas("openai")  # or anthropic/gemini/json_schema
+schemas = tools.get_schemas("openai")  # or anthropic/json_schema
+gemini_tools = tools.get_schemas("gemini")  # [{"functionDeclarations": [...]}]
 ```
 
 **Output formats:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,9 @@
-[build-system]
-requires = ["hatchling>=1.25"]
-build-backend = "hatchling.build"
-
 [project]
 name = "baretools-ai"
 dynamic = ["version"]
 description = "Minimal tooling primitives for LLM tool calling"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <4.0"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Baretools AI Contributors" }]
@@ -85,3 +81,7 @@ mode = "update"
 
 [tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"

--- a/src/baretools/core.py
+++ b/src/baretools/core.py
@@ -51,6 +51,8 @@ JSON_SCHEMA_TYPE_MAP: dict[type, str] = {
     dict: "object",
 }
 
+_SUPPORTED_PROVIDERS: tuple[str, ...] = ("openai", "anthropic", "gemini", "json_schema")
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -114,26 +116,36 @@ class ToolRegistry:
     def get_schemas(
         self,
         provider: Literal["openai", "anthropic", "gemini", "json_schema"] = "openai",
+        *,
+        strict: bool = False,
     ) -> list[dict[str, Any]]:
-        supported_providers = {"openai", "anthropic", "gemini", "json_schema"}
-        if provider not in supported_providers:
+        if provider not in _SUPPORTED_PROVIDERS:
             raise ValueError(f"Unsupported provider: {provider}")
+        if strict and provider != "openai":
+            raise ValueError("strict=True is only supported for the 'openai' provider")
+
+        if not self._tools:
+            return []
 
         if provider == "gemini":
             declarations = [
-                _tool_to_gemini_function_declaration(tool) for tool in self._tools.values()
+                _tool_to_gemini_function_declaration(registered)
+                for registered in self._tools.values()
             ]
             return [{"functionDeclarations": declarations}]
 
-        schemas: list[dict[str, Any]] = []
-        for tool in self._tools.values():
-            if provider == "openai":
-                schemas.append(_tool_to_openai_schema(tool))
-            elif provider == "anthropic":
-                schemas.append(_tool_to_anthropic_schema(tool))
-            else:
-                schemas.append(_tool_to_json_schema(tool))
-        return schemas
+        if provider == "openai":
+            return [
+                _tool_to_openai_schema(registered, strict=strict)
+                for registered in self._tools.values()
+            ]
+
+        renderers = {
+            "anthropic": _tool_to_anthropic_schema,
+            "json_schema": _tool_to_json_schema,
+        }
+        render = renderers[provider]
+        return [render(registered) for registered in self._tools.values()]
 
     def execute(
         self,
@@ -449,13 +461,35 @@ def _signature_to_json_schema(sig: Signature) -> dict[str, Any]:
     }
 
 
-def _tool_to_openai_schema(tool: RegisteredTool) -> dict[str, Any]:
+def _tool_to_openai_schema(tool: RegisteredTool, *, strict: bool = False) -> dict[str, Any]:
+    parameters = deepcopy(tool.parameters)
+    if strict:
+        properties = parameters.get("properties") or {}
+        existing_required = set(parameters.get("required") or [])
+        for prop_name, prop_schema in properties.items():
+            if prop_name not in existing_required and isinstance(prop_schema, dict):
+                prop_type = prop_schema.get("type")
+                if isinstance(prop_type, str) and prop_type != "null":
+                    prop_schema["type"] = [prop_type, "null"]
+                elif isinstance(prop_type, list) and "null" not in prop_type:
+                    prop_schema["type"] = [*prop_type, "null"]
+        parameters["required"] = list(properties.keys())
+        parameters["additionalProperties"] = False
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": parameters,
+                "strict": True,
+            },
+        }
     return {
         "type": "function",
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": deepcopy(tool.parameters),
+            "parameters": parameters,
         },
     }
 
@@ -469,11 +503,23 @@ def _tool_to_anthropic_schema(tool: RegisteredTool) -> dict[str, Any]:
 
 
 def _tool_to_gemini_function_declaration(tool: RegisteredTool) -> dict[str, Any]:
-    return {
+    declaration: dict[str, Any] = {
         "name": tool.name,
         "description": tool.description,
-        "parameters": deepcopy(tool.parameters),
     }
+    properties = tool.parameters.get("properties") or {}
+    if not properties:
+        return declaration
+
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": deepcopy(properties),
+    }
+    required = tool.parameters.get("required") or []
+    if required:
+        parameters["required"] = list(required)
+    declaration["parameters"] = parameters
+    return declaration
 
 
 def _tool_to_json_schema(tool: RegisteredTool) -> dict[str, Any]:

--- a/src/baretools/core.py
+++ b/src/baretools/core.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from inspect import Signature, _empty, signature
 from time import perf_counter, sleep
-from typing import Any, Callable, Literal, Mapping, TypedDict, TypeVar
+from typing import Any, Callable, Literal, Mapping, TypedDict, TypeVar, cast
 
 
 class ToolCall(TypedDict, total=False):
@@ -58,7 +58,7 @@ class RegisteredTool:
     name: str
     description: str
     function: Callable[..., Any]
-    schema: dict[str, Any]
+    parameters: dict[str, Any]
 
 
 def tool(
@@ -102,16 +102,31 @@ class ToolRegistry:
             raise ValueError(f"Tool '{tool_name}' already registered")
 
         sig = signature(fn)
-        schema = _function_to_openai_schema(tool_name, description, sig)
+        parameters = _signature_to_json_schema(sig)
         self._tools[tool_name] = RegisteredTool(
             name=tool_name,
             description=description,
             function=fn,
-            schema=schema,
+            parameters=parameters,
         )
 
-    def get_schemas(self) -> list[dict[str, Any]]:
-        return [tool.schema for tool in self._tools.values()]
+    def get_schemas(
+        self,
+        provider: Literal["openai", "anthropic", "gemini", "json_schema"] = "openai",
+    ) -> list[dict[str, Any]]:
+        schemas: list[dict[str, Any]] = []
+        for tool in self._tools.values():
+            if provider == "openai":
+                schemas.append(_tool_to_openai_schema(tool))
+            elif provider == "anthropic":
+                schemas.append(_tool_to_anthropic_schema(tool))
+            elif provider == "gemini":
+                schemas.append(_tool_to_gemini_schema(tool))
+            elif provider == "json_schema":
+                schemas.append(_tool_to_json_schema(tool))
+            else:
+                raise ValueError(f"Unsupported provider: {provider}")
+        return schemas
 
     def execute(
         self,
@@ -405,7 +420,7 @@ def _result(
     }
 
 
-def _function_to_openai_schema(name: str, description: str, sig: Signature) -> dict[str, Any]:
+def _signature_to_json_schema(sig: Signature) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
 
@@ -420,23 +435,61 @@ def _function_to_openai_schema(name: str, description: str, sig: Signature) -> d
             required.append(param_name)
 
     return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _tool_to_openai_schema(tool: RegisteredTool) -> dict[str, Any]:
+    return {
         "type": "function",
         "function": {
-            "name": name,
-            "description": description,
-            "parameters": {
-                "type": "object",
-                "properties": properties,
-                "required": required,
-                "additionalProperties": False,
-            },
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters,
         },
+    }
+
+
+def _tool_to_anthropic_schema(tool: RegisteredTool) -> dict[str, Any]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "input_schema": tool.parameters,
+    }
+
+
+def _tool_to_gemini_schema(tool: RegisteredTool) -> dict[str, Any]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": tool.parameters,
+    }
+
+
+def _tool_to_json_schema(tool: RegisteredTool) -> dict[str, Any]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "schema": cast(dict[str, Any], tool.parameters),
     }
 
 
 def _annotation_to_json_type(annotation: Any) -> str:
     if annotation is _empty:
         return "string"
+
+    if isinstance(annotation, str):
+        return {
+            "str": "string",
+            "int": "integer",
+            "float": "number",
+            "bool": "boolean",
+            "list": "array",
+            "dict": "object",
+        }.get(annotation, "string")
 
     origin = getattr(annotation, "__origin__", None)
     if origin is list:

--- a/src/baretools/core.py
+++ b/src/baretools/core.py
@@ -119,14 +119,18 @@ class ToolRegistry:
         if provider not in supported_providers:
             raise ValueError(f"Unsupported provider: {provider}")
 
+        if provider == "gemini":
+            declarations = [
+                _tool_to_gemini_function_declaration(tool) for tool in self._tools.values()
+            ]
+            return [{"functionDeclarations": declarations}]
+
         schemas: list[dict[str, Any]] = []
         for tool in self._tools.values():
             if provider == "openai":
                 schemas.append(_tool_to_openai_schema(tool))
             elif provider == "anthropic":
                 schemas.append(_tool_to_anthropic_schema(tool))
-            elif provider == "gemini":
-                schemas.append(_tool_to_gemini_schema(tool))
             else:
                 schemas.append(_tool_to_json_schema(tool))
         return schemas
@@ -464,7 +468,7 @@ def _tool_to_anthropic_schema(tool: RegisteredTool) -> dict[str, Any]:
     }
 
 
-def _tool_to_gemini_schema(tool: RegisteredTool) -> dict[str, Any]:
+def _tool_to_gemini_function_declaration(tool: RegisteredTool) -> dict[str, Any]:
     return {
         "name": tool.name,
         "description": tool.description,

--- a/src/baretools/core.py
+++ b/src/baretools/core.py
@@ -5,10 +5,11 @@ import inspect
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from dataclasses import dataclass
 from inspect import Signature, _empty, signature
 from time import perf_counter, sleep
-from typing import Any, Callable, Literal, Mapping, TypedDict, TypeVar, cast
+from typing import Any, Callable, Literal, Mapping, TypedDict, TypeVar
 
 
 class ToolCall(TypedDict, total=False):
@@ -114,6 +115,10 @@ class ToolRegistry:
         self,
         provider: Literal["openai", "anthropic", "gemini", "json_schema"] = "openai",
     ) -> list[dict[str, Any]]:
+        supported_providers = {"openai", "anthropic", "gemini", "json_schema"}
+        if provider not in supported_providers:
+            raise ValueError(f"Unsupported provider: {provider}")
+
         schemas: list[dict[str, Any]] = []
         for tool in self._tools.values():
             if provider == "openai":
@@ -122,10 +127,8 @@ class ToolRegistry:
                 schemas.append(_tool_to_anthropic_schema(tool))
             elif provider == "gemini":
                 schemas.append(_tool_to_gemini_schema(tool))
-            elif provider == "json_schema":
-                schemas.append(_tool_to_json_schema(tool))
             else:
-                raise ValueError(f"Unsupported provider: {provider}")
+                schemas.append(_tool_to_json_schema(tool))
         return schemas
 
     def execute(
@@ -448,7 +451,7 @@ def _tool_to_openai_schema(tool: RegisteredTool) -> dict[str, Any]:
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": tool.parameters,
+            "parameters": deepcopy(tool.parameters),
         },
     }
 
@@ -457,7 +460,7 @@ def _tool_to_anthropic_schema(tool: RegisteredTool) -> dict[str, Any]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "input_schema": tool.parameters,
+        "input_schema": deepcopy(tool.parameters),
     }
 
 
@@ -465,7 +468,7 @@ def _tool_to_gemini_schema(tool: RegisteredTool) -> dict[str, Any]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "parameters": tool.parameters,
+        "parameters": deepcopy(tool.parameters),
     }
 
 
@@ -473,7 +476,7 @@ def _tool_to_json_schema(tool: RegisteredTool) -> dict[str, Any]:
     return {
         "name": tool.name,
         "description": tool.description,
-        "schema": cast(dict[str, Any], tool.parameters),
+        "schema": deepcopy(tool.parameters),
     }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,6 +72,37 @@ def test_get_schemas_rejects_unknown_provider() -> None:
         assert "Unsupported provider" in str(exc)
 
 
+def test_get_schemas_rejects_unknown_provider_when_registry_is_empty() -> None:
+    registry = ToolRegistry()
+
+    try:
+        registry.get_schemas("unsupported")  # type: ignore[arg-type]
+        raise AssertionError("Expected ValueError")
+    except ValueError as exc:
+        assert "Unsupported provider" in str(exc)
+
+
+def test_get_schemas_returns_defensive_copies() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    openai_schemas = registry.get_schemas("openai")
+    openai_schemas[0]["function"]["parameters"]["properties"]["a"]["type"] = "string"
+
+    fresh_openai_schemas = registry.get_schemas("openai")
+    assert fresh_openai_schemas[0]["function"]["parameters"]["properties"]["a"]["type"] == "integer"
+
+    anthropic_schemas = registry.get_schemas("anthropic")
+    anthropic_schemas[0]["input_schema"]["properties"]["a"]["type"] = "string"
+
+    fresh_anthropic_schemas = registry.get_schemas("anthropic")
+    assert fresh_anthropic_schemas[0]["input_schema"]["properties"]["a"]["type"] == "integer"
+
+
 def test_error_is_captured() -> None:
     @tool
     def crash() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,6 +30,48 @@ def test_schema_generation_and_execution() -> None:
     assert results[0]["attempts"] == 1
 
 
+def test_schema_generation_for_multiple_providers() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        """Add two numbers"""
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    openai_schemas = registry.get_schemas("openai")
+    anthropic_schemas = registry.get_schemas("anthropic")
+    gemini_schemas = registry.get_schemas("gemini")
+    json_schemas = registry.get_schemas("json_schema")
+
+    assert openai_schemas[0]["type"] == "function"
+    assert openai_schemas[0]["function"]["name"] == "add"
+
+    assert anthropic_schemas[0]["name"] == "add"
+    assert anthropic_schemas[0]["input_schema"]["type"] == "object"
+
+    assert gemini_schemas[0]["name"] == "add"
+    assert gemini_schemas[0]["parameters"]["properties"]["a"]["type"] == "integer"
+
+    assert json_schemas[0]["name"] == "add"
+    assert json_schemas[0]["schema"]["required"] == ["a"]
+
+
+def test_get_schemas_rejects_unknown_provider() -> None:
+    @tool
+    def ping() -> str:
+        return "pong"
+
+    registry = ToolRegistry()
+    registry.register(ping)
+
+    try:
+        registry.get_schemas("unsupported")  # type: ignore[arg-type]
+        raise AssertionError("Expected ValueError")
+    except ValueError as exc:
+        assert "Unsupported provider" in str(exc)
+
+
 def test_error_is_captured() -> None:
     @tool
     def crash() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,8 +50,12 @@ def test_schema_generation_for_multiple_providers() -> None:
     assert anthropic_schemas[0]["name"] == "add"
     assert anthropic_schemas[0]["input_schema"]["type"] == "object"
 
-    assert gemini_schemas[0]["name"] == "add"
-    assert gemini_schemas[0]["parameters"]["properties"]["a"]["type"] == "integer"
+    assert len(gemini_schemas) == 1
+    assert gemini_schemas[0]["functionDeclarations"][0]["name"] == "add"
+    assert (
+        gemini_schemas[0]["functionDeclarations"][0]["parameters"]["properties"]["a"]["type"]
+        == "integer"
+    )
 
     assert json_schemas[0]["name"] == "add"
     assert json_schemas[0]["schema"]["required"] == ["a"]
@@ -101,6 +105,15 @@ def test_get_schemas_returns_defensive_copies() -> None:
 
     fresh_anthropic_schemas = registry.get_schemas("anthropic")
     assert fresh_anthropic_schemas[0]["input_schema"]["properties"]["a"]["type"] == "integer"
+
+    gemini_schemas = registry.get_schemas("gemini")
+    gemini_schemas[0]["functionDeclarations"][0]["parameters"]["properties"]["a"]["type"] = "string"
+
+    fresh_gemini_schemas = registry.get_schemas("gemini")
+    assert (
+        fresh_gemini_schemas[0]["functionDeclarations"][0]["parameters"]["properties"]["a"]["type"]
+        == "integer"
+    )
 
 
 def test_error_is_captured() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from time import perf_counter, sleep
 
+import pytest
+
 from baretools import ToolRegistry, format_tool_results, tool
 
 
@@ -69,21 +71,67 @@ def test_get_schemas_rejects_unknown_provider() -> None:
     registry = ToolRegistry()
     registry.register(ping)
 
-    try:
+    with pytest.raises(ValueError, match="Unsupported provider"):
         registry.get_schemas("unsupported")  # type: ignore[arg-type]
-        raise AssertionError("Expected ValueError")
-    except ValueError as exc:
-        assert "Unsupported provider" in str(exc)
 
 
 def test_get_schemas_rejects_unknown_provider_when_registry_is_empty() -> None:
     registry = ToolRegistry()
 
-    try:
+    with pytest.raises(ValueError, match="Unsupported provider"):
         registry.get_schemas("unsupported")  # type: ignore[arg-type]
-        raise AssertionError("Expected ValueError")
-    except ValueError as exc:
-        assert "Unsupported provider" in str(exc)
+
+
+def test_get_schemas_returns_empty_list_for_empty_registry() -> None:
+    registry = ToolRegistry()
+
+    assert registry.get_schemas("openai") == []
+    assert registry.get_schemas("anthropic") == []
+    assert registry.get_schemas("gemini") == []
+    assert registry.get_schemas("json_schema") == []
+
+
+def test_openai_strict_mode_marks_all_required_and_unions_optionals_with_null() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    schema = registry.get_schemas("openai", strict=True)[0]
+    assert schema["function"]["strict"] is True
+    params = schema["function"]["parameters"]
+    assert params["additionalProperties"] is False
+    assert sorted(params["required"]) == ["a", "b"]
+    assert params["properties"]["a"]["type"] == "integer"
+    assert params["properties"]["b"]["type"] == ["integer", "null"]
+
+
+def test_openai_default_is_not_strict() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    schema = registry.get_schemas("openai")[0]
+    assert "strict" not in schema["function"]
+    assert schema["function"]["parameters"]["required"] == ["a"]
+
+
+def test_strict_rejected_for_non_openai_providers() -> None:
+    @tool
+    def ping() -> str:
+        return "pong"
+
+    registry = ToolRegistry()
+    registry.register(ping)
+
+    for provider in ("anthropic", "gemini", "json_schema"):
+        with pytest.raises(ValueError, match="strict=True"):
+            registry.get_schemas(provider, strict=True)  # type: ignore[arg-type]
 
 
 def test_get_schemas_returns_defensive_copies() -> None:
@@ -114,6 +162,44 @@ def test_get_schemas_returns_defensive_copies() -> None:
         fresh_gemini_schemas[0]["functionDeclarations"][0]["parameters"]["properties"]["a"]["type"]
         == "integer"
     )
+
+
+def test_gemini_schema_omits_additional_properties() -> None:
+    @tool
+    def add(a: int, b: int = 1) -> int:
+        return a + b
+
+    registry = ToolRegistry()
+    registry.register(add)
+
+    declaration = registry.get_schemas("gemini")[0]["functionDeclarations"][0]
+    assert "additionalProperties" not in declaration["parameters"]
+    assert declaration["parameters"]["required"] == ["a"]
+
+
+def test_gemini_schema_omits_parameters_for_zero_arg_tools() -> None:
+    @tool
+    def ping() -> str:
+        return "pong"
+
+    registry = ToolRegistry()
+    registry.register(ping)
+
+    declaration = registry.get_schemas("gemini")[0]["functionDeclarations"][0]
+    assert declaration == {"name": "ping", "description": ""}
+
+
+def test_gemini_schema_omits_empty_required() -> None:
+    @tool
+    def greet(name: str = "world") -> str:
+        return f"hello {name}"
+
+    registry = ToolRegistry()
+    registry.register(greet)
+
+    declaration = registry.get_schemas("gemini")[0]["functionDeclarations"][0]
+    assert "required" not in declaration["parameters"]
+    assert declaration["parameters"]["properties"] == {"name": {"type": "string"}}
 
 
 def test_error_is_captured() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <4.0"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
### Motivation
- Expose tool schemas in multiple provider formats (OpenAI, Anthropic, Gemini, generic JSON Schema) so consumers can request the desired schema shape.
- Standardize internal representation for function parameters to enable easy conversion between provider formats.

### Description
- Replace the single `schema` field on `RegisteredTool` with `parameters` and introduce `_signature_to_json_schema` to generate a JSON Schema-style parameters object from a function `Signature`.
- Add `ToolRegistry.get_schemas(provider=...)` which returns provider-specific schema representations and dispatches to `_tool_to_openai_schema`, `_tool_to_anthropic_schema`, `_tool_to_gemini_schema`, or `_tool_to_json_schema` and raises on unknown providers.
- Update `_annotation_to_json_type` to handle string annotations and keep existing basic typing mappings, and add minor typing/cast imports to support the new helpers.
- Update the README to show the new `get_schemas("openai")` signature and mark roadmap items for Anthropic and Gemini support as completed.
- Add unit tests: `test_schema_generation_for_multiple_providers` to validate each provider format and `test_get_schemas_rejects_unknown_provider` to assert unknown providers raise `ValueError`.

### Testing
- Ran the test suite with `pytest -q`, including the new tests, and all tests passed.
- Static checks were run with `ruff check .` as configured in CI and produced no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8adf52988832a89408d64823c69a0)